### PR TITLE
Change default value of buffering parameters to value accepted by tempfile module

### DIFF
--- a/memory_tempfile/memory_tempfile.py
+++ b/memory_tempfile/memory_tempfile.py
@@ -90,19 +90,19 @@ class MemoryTempfile:
     def TemporaryDirectory(self, suffix=None, prefix=None, dir=None):
         return tempfile.TemporaryDirectory(suffix=suffix, prefix=prefix, dir=self.tempdir if not dir else dir)
     
-    def SpooledTemporaryFile(self, max_size=0, mode='w+b', buffering=None, encoding=None, newline=None,
+    def SpooledTemporaryFile(self, max_size=0, mode='w+b', buffering=-1, encoding=None, newline=None,
                              suffix=None, prefix=None, dir=None):
         return tempfile.SpooledTemporaryFile(max_size=max_size, mode=mode, buffering=buffering, encoding=encoding,
                                              newline=newline, suffix=suffix, prefix=prefix,
                                              dir=self.tempdir if not dir else dir)
 
-    def NamedTemporaryFile(self, mode='w+b', buffering=None, encoding=None, newline=None,
+    def NamedTemporaryFile(self, mode='w+b', buffering=-1, encoding=None, newline=None,
                            suffix=None, prefix=None, dir=None, delete=True):
         return tempfile.NamedTemporaryFile(mode=mode, buffering=buffering, encoding=encoding, newline=newline,
                                            suffix=suffix, prefix=prefix, dir=self.tempdir if not dir else dir,
                                            delete=delete)
     
-    def TemporaryFile(self, mode='w+b', buffering=None, encoding=None, newline=None,
+    def TemporaryFile(self, mode='w+b', buffering=-1, encoding=None, newline=None,
                       suffix=None, prefix=None, dir=None):
         return tempfile.TemporaryFile(mode=mode, buffering=buffering, encoding=encoding, newline=newline,
                                       suffix=suffix, prefix=prefix, dir=self.tempdir if not dir else dir)


### PR DESCRIPTION
Currently using NamedTemporaryFile will give this error in Python 3.7

```
Traceback (most recent call last):
...
  File "xxx.py", ...
    tempfile.NamedTemporaryFile()
  File "/home/frankier/.cache/pypoetry/virtualenvs/wsdeval-py3.7/lib/python3.7/site-packages/memory_tempfile/memory_tempfile.py", line 103, in NamedTemporaryFile
    delete=delete)
  File "/home/frankier/.pyenv/versions/3.7.3/lib/python3.7/tempfile.py", line 550, in NamedTemporaryFile
    newline=newline, encoding=encoding)
TypeError: an integer is required (got type NoneType)
```