### PR TITLE
Make it possible not to raise AttributeError when running on macOS.

### DIFF
--- a/memory_tempfile/memory_tempfile.py
+++ b/memory_tempfile/memory_tempfile.py
@@ -20,6 +20,7 @@ class MemoryTempfile:
         else:
             self.fallback = fallback
 
+        self.usable_paths = OrderedDict()
         if platform.system() == "Linux":
             self.filesystem_types = list(filesystem_types) if filesystem_types is not None else MEM_BASED_FS
             
@@ -39,7 +40,6 @@ class MemoryTempfile:
             with open('/proc/self/mountinfo', 'r') as file:
                 mnt_info = {i[2]: i for i in [line.split() for line in file]}
             
-            self.usable_paths = OrderedDict()
             for path in self.suitable_paths:
                 path = path.replace('{uid}', str(uid))
                 
@@ -58,14 +58,14 @@ class MemoryTempfile:
             
             for key in [k for k, v in self.usable_paths.items() if not v]:
                 del self.usable_paths[key]
-            
-            if len(self.usable_paths) > 0:
-                self.tempdir = next(iter(self.usable_paths.keys()))
+
+        if len(self.usable_paths) > 0:
+            self.tempdir = next(iter(self.usable_paths.keys()))
+        else:
+            if fallback:
+                self.tempdir = self.fallback
             else:
-                if fallback:
-                    self.tempdir = self.fallback
-                else:
-                    raise RuntimeError('No memory temporary dir found and fallback is disabled.')
+                raise RuntimeError('No memory temporary dir found and fallback is disabled.')
 
     def found_mem_tempdir(self):
         return len(self.usable_paths) > 0


### PR DESCRIPTION
Issue: https://github.com/mbello/memory-tempfile/issues/5

Initialize the attribute that caused the attribute error even in the non-Linux environment.

It was necessary to pay attention to the execution environment when calling found_mem_tempdir().
```python
tempfile = MemoryTempfile()
if platform.system() == "Linux":
    if tempfile.found_mem_tempdir():
        pass
```

This PR make it possible to control it with the fallback option, even if it's a non-Linux environment.
```python
tempfile = MemoryTempfile(fallback=True)
if tempfile.found_mem_tempdir():
    pass
```

I've confirmed the following.

Even on macOS, RuntimeError is raised if fallback is not specified. This makes it easier to investigate from an error message than an AttributeError.
```
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.15.4
BuildVersion:   19E287

$ cat x.py
from memory_tempfile import MemoryTempfile

tempfile = MemoryTempfile()
if tempfile.found_mem_tempdir():
    pass

$ python x.py
Traceback (most recent call last):
  File "x.py", line 3, in <module>
    tempfile = MemoryTempfile()
  File "/Users/otms61/.ghq/github.com/otms61/memory-tempfile/memory_tempfile/memory_tempfile.py", line 68, in __init__
    raise RuntimeError('No memory temporary dir found and fallback is disabled.')
RuntimeError: No memory temporary dir found and fallback is disabled.
```

Also, if you specify "fallback=True", you can use a default tempdir.
```
$ cat x.py
from memory_tempfile import MemoryTempfile

tempfile = MemoryTempfile(fallback=True)
if tempfile.found_mem_tempdir():
    pass

$ python x.py

$
```