### PR TITLE
Handle /proc/self/mountinfo optional fields

### DIFF
--- a/memory_tempfile/memory_tempfile.py
+++ b/memory_tempfile/memory_tempfile.py
@@ -51,7 +51,7 @@ class MemoryTempfile:
                     dev = os.stat(path).st_dev
                     major, minor = os.major(dev), os.minor(dev)
                     mp = mnt_info.get("{}:{}".format(major, minor))
-                    if mp and mp[8] in self.filesystem_types:
+                    if mp and mp[mp.index("-",6)+1] in self.filesystem_types:
                         self.usable_paths[path] = mp
                 except FileNotFoundError:
                     pass


### PR DESCRIPTION
I've observed the following when attempting to invoke `memory_tempfile.MemoryTempfile()` in a Docker container (macOS host, Docker Engine 19.03.13 w/ 5.4.39-linuxkit kernel, python:3.8-slim container image based on Debian 10):

```
RuntimeError: No memory temporary dir found and fallback is disabled.
```

Per the procfs(5) man page, the 7th and immediately-subsequent fields are:

> (7)  optional fields: zero or more fields of the form "tag[:value]"; see below.
> 
> (8)  separator: the end of the optional fields is marked by a single hyphen.
> 
> (9)  filesystem type: the filesystem type in the form "type[.subtype]".

memory_tempfile.MemoryTempfile assumes the existence of exactly one optional field at:

https://github.com/mbello/memory-tempfile/blob/v2.2.3/memory_tempfile/memory_tempfile.py#L54

There are no optional fields present in /proc/self/mountinfo in the container.

This patch scans for the first occurrence of a hyphen starting at field 7, and uses the next field as the filesystem type.