### PR TITLE
Build with poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ pytest = "^5.3.3"
 pytest-benchmark = "^3.2.3"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This is the lightweight PEP517 build backend cut out of the original poetry project, and should be preferred for distribution.

https://github.com/python-poetry/poetry-core?tab=readme-ov-file#why-is-this-required